### PR TITLE
coin::transfer to supra_account::transfer

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-#  reward_distribution = "0x7871b01b6e827eb648e29a0e43a1f65b7a9878ca1d89e6cd96e34eff26abcd19"
+# reward_distribution = "0xbc72119906a27154d2c0d0566eae276115c9e992a41d4bd9b901ecc81f927348"
 reward_distribution = "_"
 
 [dev-addresses]

--- a/sources/merkle_tree_distribution.move
+++ b/sources/merkle_tree_distribution.move
@@ -247,8 +247,6 @@ module reward_distribution::merkle_tree_distribution {
         assert!(entitled_cumulative > claimed_total, error::invalid_state(E_NOTHING_TO_CLAIM));
         let payout = entitled_cumulative - claimed_total;
 
-        // assert!(coin::is_account_registered<SupraCoin>(user), error::invalid_state(E_SUPRA_COIN_NOT_REGISTERED));
-
         let vault_signer = get_vault_signer();
         assert!(get_vault_balance() >= payout, error::invalid_state(E_INSUFFICIENT_VAULT_FUNDS));
 

--- a/sources/merkle_tree_distribution.move
+++ b/sources/merkle_tree_distribution.move
@@ -5,6 +5,7 @@ module reward_distribution::merkle_tree_distribution {
     use std::signer;
     use std::vector;
     use std::error;
+    use supra_framework::supra_account;
 
     use supra_framework::bcs;
     use supra_framework::hash;
@@ -246,12 +247,12 @@ module reward_distribution::merkle_tree_distribution {
         assert!(entitled_cumulative > claimed_total, error::invalid_state(E_NOTHING_TO_CLAIM));
         let payout = entitled_cumulative - claimed_total;
 
-        assert!(coin::is_account_registered<SupraCoin>(user), error::invalid_state(E_SUPRA_COIN_NOT_REGISTERED));
+        // assert!(coin::is_account_registered<SupraCoin>(user), error::invalid_state(E_SUPRA_COIN_NOT_REGISTERED));
 
         let vault_signer = get_vault_signer();
         assert!(get_vault_balance() >= payout, error::invalid_state(E_INSUFFICIENT_VAULT_FUNDS));
 
-        coin::transfer<SupraCoin>(&vault_signer, user, payout);
+        supra_account::transfer(&vault_signer, user, payout);
 
         internal_set_claimed_total(user, entitled_cumulative, payout);
 


### PR DESCRIPTION
added supra_account transfer instead of coin::transfer to automaticaly create supra account when the receiver account is new